### PR TITLE
Add support for using Remote Desktop Gateway servers. 

### DIFF
--- a/QuickConnectPlugin.FormLauchers/QuickConnectPlugin.FormLauchers.csproj
+++ b/QuickConnectPlugin.FormLauchers/QuickConnectPlugin.FormLauchers.csproj
@@ -59,7 +59,6 @@
     <Reference Include="System.Windows.Forms" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="InMemoryQuickConnectPluginSettings.cs" />
     <Compile Include="ProgramOptions.cs" />
     <Compile Include="ProgramPasswordChanger.cs" />
     <Compile Include="FakePasswordChangerExFactoryThatThrowsException.cs" />

--- a/QuickConnectPlugin.Tests/ArgumentsFormatters/RemoteDesktopArgumentsFormatterTests.cs
+++ b/QuickConnectPlugin.Tests/ArgumentsFormatters/RemoteDesktopArgumentsFormatterTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using NUnit.Framework;
 using QuickConnectPlugin.ArgumentsFormatters;
+using QuickConnectPlugin.FormLauchers;
 
 namespace QuickConnectPlugin.Tests.ArgumentsFormatters {
 
@@ -15,8 +16,8 @@ namespace QuickConnectPlugin.Tests.ArgumentsFormatters {
                 IPAddress = "127.0.0.1"
             };
             pwEntry.ConnectionMethods.Add(ConnectionMethodType.RemoteDesktop);
-
-            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter();
+            InMemoryQuickConnectPluginSettings pluginSettings = new InMemoryQuickConnectPluginSettings();
+            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter(pluginSettings);
             Assert.AreEqual(String.Format("\"{0}\" /v:127.0.0.1", RemoteDesktopArgumentsFormatter.RemoteDesktopClientPath), argumentsFormatter.Format(pwEntry));
         }
 
@@ -28,8 +29,8 @@ namespace QuickConnectPlugin.Tests.ArgumentsFormatters {
                 IPAddress = "127.0.0.1"
             };
             pwEntry.ConnectionMethods.Add(ConnectionMethodType.RemoteDesktop);
-
-            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter() {
+            InMemoryQuickConnectPluginSettings pluginSettings = new InMemoryQuickConnectPluginSettings();
+            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter(pluginSettings) {
                 UseConsole = true
             };
             Assert.AreEqual(String.Format("\"{0}\" /v:127.0.0.1 /admin", RemoteDesktopArgumentsFormatter.RemoteDesktopClientPath), argumentsFormatter.Format(pwEntry));
@@ -43,8 +44,8 @@ namespace QuickConnectPlugin.Tests.ArgumentsFormatters {
                 IPAddress = "127.0.0.1"
             };
             pwEntry.ConnectionMethods.Add(ConnectionMethodType.RemoteDesktop);
-
-            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter() {
+            InMemoryQuickConnectPluginSettings pluginSettings = new InMemoryQuickConnectPluginSettings();
+            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter(pluginSettings) {
                 UseConsole = true,
                 IsOlderVersion = true
             };
@@ -59,8 +60,8 @@ namespace QuickConnectPlugin.Tests.ArgumentsFormatters {
                 IPAddress = "127.0.0.1"
             };
             pwEntry.ConnectionMethods.Add(ConnectionMethodType.RemoteDesktop);
-
-            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter() {
+            InMemoryQuickConnectPluginSettings pluginSettings = new InMemoryQuickConnectPluginSettings();
+            RemoteDesktopArgumentsFormatter argumentsFormatter = new RemoteDesktopArgumentsFormatter(pluginSettings) {
                 FullScreen = true
             };
             Assert.AreEqual(String.Format("\"{0}\" /v:127.0.0.1 /f", RemoteDesktopArgumentsFormatter.RemoteDesktopClientPath), argumentsFormatter.Format(pwEntry));

--- a/QuickConnectPlugin.Tests/InMemoryQuickConnectPluginSettings.cs
+++ b/QuickConnectPlugin.Tests/InMemoryQuickConnectPluginSettings.cs
@@ -14,6 +14,7 @@ namespace QuickConnectPlugin.FormLauchers {
         public string HostAddressMapFieldName { get; set; }
         public string ConnectionMethodMapFieldName { get; set; }
         public string AdditionalOptionsMapFieldName { get; set; }
+        public string RdpPlusLocation { get; set; }
 
         public void Load() {
             Debug.WriteLine(this.GetType().Name + ".Load()");

--- a/QuickConnectPlugin.Tests/QuickConnectPlugin.Tests.csproj
+++ b/QuickConnectPlugin.Tests/QuickConnectPlugin.Tests.csproj
@@ -69,6 +69,7 @@
     <Compile Include="Extensions\PwDatabaseExtensionsTests2.cs" />
     <Compile Include="Extensions\PwDatabaseExtensionsTests.cs" />
     <Compile Include="FakePuttySessionFinder.cs" />
+    <Compile Include="InMemoryQuickConnectPluginSettings.cs" />
     <Compile Include="PasswordChanger\BatchPasswordChangerWorkerTests.cs" />
     <Compile Include="PasswordChanger\HostTypeMapperTests.cs" />
     <Compile Include="PasswordChanger\HostTypeSafeConverterTests.cs" />

--- a/QuickConnectPlugin/ArgumentsFormatters/RemoteDesktopArgumentsFormatter.cs
+++ b/QuickConnectPlugin/ArgumentsFormatters/RemoteDesktopArgumentsFormatter.cs
@@ -11,12 +11,22 @@ namespace QuickConnectPlugin.ArgumentsFormatters {
         public bool UseConsole { get; set; }
         public bool IsOlderVersion { get; set; }
 
-        public RemoteDesktopArgumentsFormatter() {
+        public RemoteDesktopArgumentsFormatter(IQuickConnectPluginSettings pluginSettings) {
+            _pluginSettings = pluginSettings;
         }
+
+        private IQuickConnectPluginSettings _pluginSettings;
 
         public string Format(IHostPwEntry hostPwEntry) {
             StringBuilder sb = new StringBuilder();
-            sb.AppendFormat("\"{0}\"", RemoteDesktopClientPath);
+
+            var xUseRdpPlus = !string.IsNullOrEmpty(_pluginSettings.RdpPlusPath);
+            if (xUseRdpPlus) {
+                sb.AppendFormat("\"{0}\"", _pluginSettings.RdpPlusPath);
+            } else {
+                sb.AppendFormat("\"{0}\"", RemoteDesktopClientPath);
+            }
+
             sb.AppendFormat(" /v:{0}", hostPwEntry.IPAddress);
 
             if (this.FullScreen) {
@@ -28,6 +38,23 @@ namespace QuickConnectPlugin.ArgumentsFormatters {
                 }
                 else {
                     sb.Append(" /admin");
+                }
+            }
+
+            sb.AppendFormat(" /u:\"{0}\"", hostPwEntry.GetUsername());
+            sb.AppendFormat(" /p:\"{0}\"", hostPwEntry.GetPassword());
+
+            if (xUseRdpPlus) {
+                RdpPlusOptions options;
+                if (RdpPlusOptionsParser.TryParse(hostPwEntry.AdditionalOptions, out options)) {
+                    if (!string.IsNullOrEmpty(options.RDGateway)) {
+                        var extraOptions = "gatewayhostname:s:" + options.RDGateway + ", gatewayusagemethod:i:2, gatewaycredentialssource:i:4, gatewayprofileusagemethod:i:1, gatewaybrokeringtype:i:0";
+                        if (options.UseSameCredentials) {
+                            extraOptions += ", promptcredentialonce:i:1";
+                        }
+
+                        sb.Append(" /o:\"" + extraOptions + "\"");
+                    }
                 }
             }
 

--- a/QuickConnectPlugin/FormOptions.Designer.cs
+++ b/QuickConnectPlugin/FormOptions.Designer.cs
@@ -61,6 +61,11 @@
             this.buttonApply = new System.Windows.Forms.Button();
             this.buttonCancel = new System.Windows.Forms.Button();
             this.buttonOK = new System.Windows.Forms.Button();
+            this.groupBox7 = new System.Windows.Forms.GroupBox();
+            this.buttonConfigureRdpPlusPath = new System.Windows.Forms.Button();
+            this.textBoxRdpPlusPath = new System.Windows.Forms.TextBox();
+            this.pictureBoxRdpPlusPathWarningIcon = new System.Windows.Forms.PictureBox();
+            this.labelRdpPlusPathWarningMessage = new System.Windows.Forms.Label();
             this.tabControl.SuspendLayout();
             this.tabPage1.SuspendLayout();
             this.groupBox3.SuspendLayout();
@@ -76,39 +81,47 @@
             this.groupBox4.SuspendLayout();
             this.tabPage3.SuspendLayout();
             this.groupBox12.SuspendLayout();
+            this.groupBox7.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxRdpPlusPathWarningIcon)).BeginInit();
             this.SuspendLayout();
             // 
             // tabControl
             // 
+            this.tabControl.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.tabControl.Controls.Add(this.tabPage1);
             this.tabControl.Controls.Add(this.tabPage2);
             this.tabControl.Controls.Add(this.tabPage3);
             this.tabControl.Location = new System.Drawing.Point(12, 12);
             this.tabControl.Name = "tabControl";
             this.tabControl.SelectedIndex = 0;
-            this.tabControl.Size = new System.Drawing.Size(305, 294);
+            this.tabControl.Size = new System.Drawing.Size(305, 372);
             this.tabControl.TabIndex = 0;
             // 
             // tabPage1
             // 
+            this.tabPage1.Controls.Add(this.groupBox7);
             this.tabPage1.Controls.Add(this.groupBox3);
             this.tabPage1.Controls.Add(this.groupBox2);
             this.tabPage1.Controls.Add(this.groupBox1);
             this.tabPage1.Location = new System.Drawing.Point(4, 22);
             this.tabPage1.Name = "tabPage1";
             this.tabPage1.Padding = new System.Windows.Forms.Padding(3);
-            this.tabPage1.Size = new System.Drawing.Size(297, 268);
+            this.tabPage1.Size = new System.Drawing.Size(297, 346);
             this.tabPage1.TabIndex = 0;
             this.tabPage1.Text = "General";
             this.tabPage1.UseVisualStyleBackColor = true;
             // 
             // groupBox3
             // 
+            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox3.Controls.Add(this.pictureBoxWinScpPathWarningIcon);
             this.groupBox3.Controls.Add(this.labelWinScpPathWarningMessage);
             this.groupBox3.Controls.Add(this.buttonConfigureWinScpPath);
             this.groupBox3.Controls.Add(this.textBoxWinScpPath);
-            this.groupBox3.Location = new System.Drawing.Point(3, 184);
+            this.groupBox3.Location = new System.Drawing.Point(3, 164);
             this.groupBox3.Name = "groupBox3";
             this.groupBox3.Size = new System.Drawing.Size(290, 80);
             this.groupBox3.TabIndex = 8;
@@ -156,11 +169,13 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox2.Controls.Add(this.pictureBoxSSHClientPathWarningIcon);
             this.groupBox2.Controls.Add(this.labelSSHClientPathWarningMessage);
             this.groupBox2.Controls.Add(this.buttonConfigureSSHClientPath);
             this.groupBox2.Controls.Add(this.textBoxSSHClientPath);
-            this.groupBox2.Location = new System.Drawing.Point(3, 97);
+            this.groupBox2.Location = new System.Drawing.Point(3, 78);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(290, 80);
             this.groupBox2.TabIndex = 4;
@@ -210,11 +225,13 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox1.Controls.Add(this.checkBoxCompatibleMode);
             this.groupBox1.Controls.Add(this.checkBoxEnable);
             this.groupBox1.Location = new System.Drawing.Point(3, 1);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(290, 90);
+            this.groupBox1.Size = new System.Drawing.Size(290, 71);
             this.groupBox1.TabIndex = 1;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Settings";
@@ -254,6 +271,8 @@
             // 
             // groupBox6
             // 
+            this.groupBox6.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox6.Controls.Add(this.pictureBoxVSpherePowerCLIStatusIcon);
             this.groupBox6.Controls.Add(this.labelVSpherePowerCLIStatusMessage);
             this.groupBox6.Location = new System.Drawing.Point(3, 184);
@@ -289,6 +308,8 @@
             // 
             // groupBox5
             // 
+            this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox5.Controls.Add(this.pictureBoxPsPasswdPathWarningIcon);
             this.groupBox5.Controls.Add(this.labelPsPasswdPathWarningMessage);
             this.groupBox5.Controls.Add(this.buttonConfigurePsPasswdPath);
@@ -343,6 +364,8 @@
             // 
             // groupBox4
             // 
+            this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox4.Controls.Add(this.checkBoxAddChangePasswordItem);
             this.groupBox4.Location = new System.Drawing.Point(3, 1);
             this.groupBox4.Name = "groupBox4";
@@ -373,6 +396,8 @@
             // 
             // groupBox12
             // 
+            this.groupBox12.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.groupBox12.Controls.Add(this.comboBoxAdditionalOptionsMapFieldName);
             this.groupBox12.Controls.Add(this.label3);
             this.groupBox12.Controls.Add(this.labelWarningMessage);
@@ -454,7 +479,8 @@
             // 
             // buttonApply
             // 
-            this.buttonApply.Location = new System.Drawing.Point(238, 313);
+            this.buttonApply.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.buttonApply.Location = new System.Drawing.Point(238, 391);
             this.buttonApply.Name = "buttonApply";
             this.buttonApply.Size = new System.Drawing.Size(75, 23);
             this.buttonApply.TabIndex = 1;
@@ -464,8 +490,9 @@
             // 
             // buttonCancel
             // 
+            this.buttonCancel.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonCancel.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.buttonCancel.Location = new System.Drawing.Point(157, 313);
+            this.buttonCancel.Location = new System.Drawing.Point(157, 391);
             this.buttonCancel.Name = "buttonCancel";
             this.buttonCancel.Size = new System.Drawing.Size(75, 23);
             this.buttonCancel.TabIndex = 2;
@@ -474,8 +501,9 @@
             // 
             // buttonOK
             // 
+            this.buttonOK.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.buttonOK.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.buttonOK.Location = new System.Drawing.Point(76, 313);
+            this.buttonOK.Location = new System.Drawing.Point(76, 391);
             this.buttonOK.Name = "buttonOK";
             this.buttonOK.Size = new System.Drawing.Size(75, 23);
             this.buttonOK.TabIndex = 3;
@@ -483,13 +511,67 @@
             this.buttonOK.UseVisualStyleBackColor = true;
             this.buttonOK.Click += new System.EventHandler(this.buttonOK_Click);
             // 
+            // groupBox7
+            // 
+            this.groupBox7.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.groupBox7.Controls.Add(this.pictureBoxRdpPlusPathWarningIcon);
+            this.groupBox7.Controls.Add(this.labelRdpPlusPathWarningMessage);
+            this.groupBox7.Controls.Add(this.buttonConfigureRdpPlusPath);
+            this.groupBox7.Controls.Add(this.textBoxRdpPlusPath);
+            this.groupBox7.Location = new System.Drawing.Point(3, 250);
+            this.groupBox7.Name = "groupBox7";
+            this.groupBox7.Size = new System.Drawing.Size(290, 80);
+            this.groupBox7.TabIndex = 9;
+            this.groupBox7.TabStop = false;
+            this.groupBox7.Text = "Rdp+ Path (Optional)";
+            // 
+            // buttonConfigureRdpPlusPath
+            // 
+            this.buttonConfigureRdpPlusPath.Location = new System.Drawing.Point(207, 44);
+            this.buttonConfigureRdpPlusPath.Name = "buttonConfigureRdpPlusPath";
+            this.buttonConfigureRdpPlusPath.Size = new System.Drawing.Size(77, 24);
+            this.buttonConfigureRdpPlusPath.TabIndex = 4;
+            this.buttonConfigureRdpPlusPath.Text = "Configure...";
+            this.buttonConfigureRdpPlusPath.UseVisualStyleBackColor = true;
+            this.buttonConfigureRdpPlusPath.Click += new System.EventHandler(this.buttonConfigureRdpPlusPath_Click);
+            // 
+            // textBoxRdpPlusPath
+            // 
+            this.textBoxRdpPlusPath.Location = new System.Drawing.Point(19, 19);
+            this.textBoxRdpPlusPath.Name = "textBoxRdpPlusPath";
+            this.textBoxRdpPlusPath.Size = new System.Drawing.Size(265, 20);
+            this.textBoxRdpPlusPath.TabIndex = 0;
+            // 
+            // pictureBoxRdpPlusPathWarningIcon
+            // 
+            this.pictureBoxRdpPlusPathWarningIcon.ErrorImage = null;
+            this.pictureBoxRdpPlusPathWarningIcon.Image = global::QuickConnectPlugin.Properties.Resources.important;
+            this.pictureBoxRdpPlusPathWarningIcon.Location = new System.Drawing.Point(19, 48);
+            this.pictureBoxRdpPlusPathWarningIcon.Name = "pictureBoxRdpPlusPathWarningIcon";
+            this.pictureBoxRdpPlusPathWarningIcon.Size = new System.Drawing.Size(16, 16);
+            this.pictureBoxRdpPlusPathWarningIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.AutoSize;
+            this.pictureBoxRdpPlusPathWarningIcon.TabIndex = 9;
+            this.pictureBoxRdpPlusPathWarningIcon.TabStop = false;
+            // 
+            // labelRdpPlusPathWarningMessage
+            // 
+            this.labelRdpPlusPathWarningMessage.AutoSize = true;
+            this.labelRdpPlusPathWarningMessage.Location = new System.Drawing.Point(38, 50);
+            this.labelRdpPlusPathWarningMessage.Name = "labelRdpPlusPathWarningMessage";
+            this.labelRdpPlusPathWarningMessage.RightToLeft = System.Windows.Forms.RightToLeft.No;
+            this.labelRdpPlusPathWarningMessage.Size = new System.Drawing.Size(151, 13);
+            this.labelRdpPlusPathWarningMessage.TabIndex = 8;
+            this.labelRdpPlusPathWarningMessage.Text = "Specified path does not exists.";
+            this.labelRdpPlusPathWarningMessage.TextAlign = System.Drawing.ContentAlignment.MiddleLeft;
+            // 
             // FormOptions
             // 
             this.AcceptButton = this.buttonOK;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.buttonCancel;
-            this.ClientSize = new System.Drawing.Size(329, 342);
+            this.ClientSize = new System.Drawing.Size(329, 420);
             this.Controls.Add(this.buttonOK);
             this.Controls.Add(this.buttonCancel);
             this.Controls.Add(this.buttonApply);
@@ -526,6 +608,9 @@
             this.tabPage3.ResumeLayout(false);
             this.groupBox12.ResumeLayout(false);
             this.groupBox12.PerformLayout();
+            this.groupBox7.ResumeLayout(false);
+            this.groupBox7.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.pictureBoxRdpPlusPathWarningIcon)).EndInit();
             this.ResumeLayout(false);
 
         }
@@ -570,5 +655,10 @@
         private System.Windows.Forms.GroupBox groupBox6;
         private System.Windows.Forms.PictureBox pictureBoxVSpherePowerCLIStatusIcon;
         private System.Windows.Forms.Label labelVSpherePowerCLIStatusMessage;
+        private System.Windows.Forms.GroupBox groupBox7;
+        private System.Windows.Forms.Button buttonConfigureRdpPlusPath;
+        private System.Windows.Forms.TextBox textBoxRdpPlusPath;
+        private System.Windows.Forms.PictureBox pictureBoxRdpPlusPathWarningIcon;
+        private System.Windows.Forms.Label labelRdpPlusPathWarningMessage;
     }
 }

--- a/QuickConnectPlugin/FormOptions.cs
+++ b/QuickConnectPlugin/FormOptions.cs
@@ -29,6 +29,9 @@ namespace QuickConnectPlugin {
             this.textBoxWinScpPath.Text = settings.WinScpPath;
             this.textBoxWinScpPath.Select(this.textBoxWinScpPath.Text.Length, 0);
 
+            this.textBoxRdpPlusPath.Text = settings.RdpPlusPath;
+            this.textBoxRdpPlusPath.Select(this.textBoxRdpPlusPath.Text.Length, 0);
+
             this.textBoxPsPasswdPath.Text = settings.PsPasswdPath;
             this.textBoxPsPasswdPath.Select(this.textBoxPsPasswdPath.Text.Length, 0);
 
@@ -94,6 +97,7 @@ namespace QuickConnectPlugin {
             this.checkBoxAddChangePasswordItem.CheckedChanged += new EventHandler(settingsChanged);
             this.textBoxSSHClientPath.TextChanged += new EventHandler(settingsChanged);
             this.textBoxWinScpPath.TextChanged += new EventHandler(settingsChanged);
+            this.textBoxRdpPlusPath.TextChanged += new EventHandler(settingsChanged);
             this.textBoxPsPasswdPath.TextChanged += new EventHandler(settingsChanged);
             this.comboBoxHostAddressMapFieldName.SelectedIndexChanged += new EventHandler(settingsChanged);
             this.comboBoxConnectionMethodMapFieldName.SelectedIndexChanged += new EventHandler(settingsChanged);
@@ -125,6 +129,7 @@ namespace QuickConnectPlugin {
             this.settings.AddChangePasswordMenuItem = this.checkBoxAddChangePasswordItem.Checked;
             this.settings.SSHClientPath = this.textBoxSSHClientPath.Text;
             this.settings.WinScpPath = this.textBoxWinScpPath.Text;
+            this.settings.RdpPlusPath = this.textBoxRdpPlusPath.Text;
             this.settings.PsPasswdPath = this.textBoxPsPasswdPath.Text;
             this.settings.HostAddressMapFieldName = (String)this.comboBoxHostAddressMapFieldName.SelectedItem;
             this.settings.ConnectionMethodMapFieldName = (String)this.comboBoxConnectionMethodMapFieldName.SelectedItem;
@@ -150,6 +155,16 @@ namespace QuickConnectPlugin {
             }
             else {
                 this.textBoxWinScpPath.BackColor = default(Color);
+                return true;
+            }
+        }
+
+        private bool isRdpPlusPathValid() {
+            if (this.textBoxRdpPlusPath.Text.Length == 0 || !File.Exists(this.textBoxRdpPlusPath.Text)) {
+                // Allow path to be empty.
+                return (this.textBoxRdpPlusPath.Text.Length == 0);
+            } else {
+                this.textBoxRdpPlusPath.BackColor = default(Color);
                 return true;
             }
         }
@@ -200,7 +215,11 @@ namespace QuickConnectPlugin {
             this.pictureBoxWinScpPathWarningIcon.Visible = !isValidWinScpPath;
             this.labelWinScpPathWarningMessage.Visible = !isValidWinScpPath;
 
-            return isValidSSHClientPath && isValidWinScpPath && isPsPasswdPathValid();
+            bool isValidRdpPlusPath = isRdpPlusPathValid();
+            this.pictureBoxRdpPlusPathWarningIcon.Visible = !isValidRdpPlusPath;
+            this.labelRdpPlusPathWarningMessage.Visible = !isValidRdpPlusPath;
+
+            return isValidSSHClientPath && isValidWinScpPath && isValidRdpPlusPath && isPsPasswdPathValid();
         }
 
         private void buttonConfigureSSHClientPath_Click(object sender, EventArgs e) {
@@ -267,6 +286,26 @@ namespace QuickConnectPlugin {
             );
             if (status) {
                 this.pictureBoxVSpherePowerCLIStatusIcon.Image = global::QuickConnectPlugin.Properties.Resources.success;
+            }
+        }
+
+        private void buttonConfigureRdpPlusPath_Click(object sender, EventArgs e) {
+            using (OpenFileDialog openFileDialog = new OpenFileDialog()) {
+                openFileDialog.Multiselect = false;
+                if (File.Exists(this.textBoxRdpPlusPath.Text))
+                {
+                    openFileDialog.InitialDirectory = Path.GetDirectoryName(this.textBoxRdpPlusPath.Text);
+                    openFileDialog.FileName = Path.GetFileName(this.textBoxRdpPlusPath.Text);
+                }
+                openFileDialog.CheckFileExists = true;
+                openFileDialog.CheckPathExists = true;
+                openFileDialog.Filter = "Rdp+ executable (*.exe)|*.exe|All files (*.*)|*.*";
+                openFileDialog.Title = "Select Rdp+ Path";
+                DialogResult result = openFileDialog.ShowDialog();
+                if (result == DialogResult.OK && !String.IsNullOrEmpty(openFileDialog.FileName)) {
+                    this.textBoxRdpPlusPath.Text = openFileDialog.FileName;
+                    this.textBoxRdpPlusPath.Select(this.textBoxRdpPlusPath.Text.Length, 0);
+                }
             }
         }
     }

--- a/QuickConnectPlugin/IFieldMapper.cs
+++ b/QuickConnectPlugin/IFieldMapper.cs
@@ -7,5 +7,6 @@ namespace QuickConnectPlugin {
         String HostAddress { get; }
         String ConnectionMethod { get; }
         String AdditionalOptions { get; }
+        
     }
 }

--- a/QuickConnectPlugin/IQuickConnectPluginSettings.cs
+++ b/QuickConnectPlugin/IQuickConnectPluginSettings.cs
@@ -59,5 +59,6 @@ namespace QuickConnectPlugin {
         /// </summary>
         void Save();
 
+        string RdpPlusPath { get; set; }
     }
 }

--- a/QuickConnectPlugin/QuickConnectPlugin.csproj
+++ b/QuickConnectPlugin/QuickConnectPlugin.csproj
@@ -97,6 +97,8 @@
     <Compile Include="PasswordChanger\Services\IPasswordChangerServiceFactory.cs" />
     <Compile Include="PasswordChanger\Services\PasswordChangerServiceFactory.cs" />
     <Compile Include="Extensions\PwDatabaseExtensions.cs" />
+    <Compile Include="RdpPlusOptions.cs" />
+    <Compile Include="RdpPlusOptionsParser.cs" />
     <Compile Include="Workers\CancelableWorker.cs" />
     <Compile Include="Workers\ICancelable.cs" />
     <Compile Include="Workers\Worker.cs" />

--- a/QuickConnectPlugin/QuickConnectPlugin.csproj.user
+++ b/QuickConnectPlugin/QuickConnectPlugin.csproj.user
@@ -3,4 +3,8 @@
   <PropertyGroup>
     <ProjectView>ProjectFiles</ProjectView>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <StartAction>Program</StartAction>
+    <StartProgram>e:\Data\Sources\OpenSource\KeePass-QuickConnectPlugin\QuickConnectPlugin\bin\Debug\KeePass.exe</StartProgram>
+  </PropertyGroup>
 </Project>

--- a/QuickConnectPlugin/QuickConnectPluginExt.cs
+++ b/QuickConnectPlugin/QuickConnectPluginExt.cs
@@ -199,7 +199,7 @@ namespace QuickConnectPlugin {
                     delegate(object obj, EventArgs ev) {
                         try {
                             ProcessUtils.Start(CmdKeyRegisterArgumentsFormatter.CmdKeyPath, new CmdKeyRegisterArgumentsFormatter().Format(hostPwEntry));
-                            IArgumentsFormatter argsFormatter = new RemoteDesktopArgumentsFormatter() {
+                            IArgumentsFormatter argsFormatter = new RemoteDesktopArgumentsFormatter(Settings) {
                                 FullScreen = true
                             };
                             ProcessUtils.StartDetached(argsFormatter.Format(hostPwEntry));
@@ -222,7 +222,7 @@ namespace QuickConnectPlugin {
                   delegate(object obj, EventArgs ev) {
                       try {
                           ProcessUtils.Start(CmdKeyRegisterArgumentsFormatter.CmdKeyPath, new CmdKeyRegisterArgumentsFormatter().Format(hostPwEntry));
-                          IArgumentsFormatter argsFormatter = new RemoteDesktopArgumentsFormatter() {
+                          IArgumentsFormatter argsFormatter = new RemoteDesktopArgumentsFormatter(Settings) {
                               FullScreen = true,
                               UseConsole = true,
                               IsOlderVersion = RDCIsOlderVersion

--- a/QuickConnectPlugin/QuickConnectPluginSettings.cs
+++ b/QuickConnectPlugin/QuickConnectPluginSettings.cs
@@ -15,6 +15,7 @@ namespace QuickConnectPlugin {
         public string HostAddressMapFieldName { get; set; }
         public string ConnectionMethodMapFieldName { get; set; }
         public string AdditionalOptionsMapFieldName { get; set; }
+        public string RdpPlusPath { get; set; }
 
         private ICustomConfigPropertyNameFormatter formatter;
         private IPluginHost plugin;
@@ -43,6 +44,7 @@ namespace QuickConnectPlugin {
             this.HostAddressMapFieldName = this.plugin.CustomConfig.GetString(this.formatter.Format("HostAddressMapFieldName"), String.Empty);
             this.ConnectionMethodMapFieldName = this.plugin.CustomConfig.GetString(this.formatter.Format("ConnectionMethodMapFieldName"), String.Empty);
             this.AdditionalOptionsMapFieldName = this.plugin.CustomConfig.GetString(this.formatter.Format("AdditionalOptionsMapFieldName"), String.Empty);
+            this.RdpPlusPath = this.plugin.CustomConfig.GetString(this.formatter.Format("RdpPlusPath"), String.Empty);
         }
 
         /// <summary>
@@ -58,6 +60,7 @@ namespace QuickConnectPlugin {
             this.plugin.CustomConfig.SetString(this.formatter.Format("HostAddressMapFieldName"), this.HostAddressMapFieldName);
             this.plugin.CustomConfig.SetString(this.formatter.Format("ConnectionMethodMapFieldName"), this.ConnectionMethodMapFieldName);
             this.plugin.CustomConfig.SetString(this.formatter.Format("AdditionalOptionsMapFieldName"), this.AdditionalOptionsMapFieldName);
+            this.plugin.CustomConfig.SetString(this.formatter.Format("RdpPlusPath"), this.RdpPlusPath);
         }
     }
 }

--- a/QuickConnectPlugin/RdpPlusOptions.cs
+++ b/QuickConnectPlugin/RdpPlusOptions.cs
@@ -1,0 +1,10 @@
+﻿using System.Security.Policy;
+
+namespace QuickConnectPlugin
+{
+    public class RdpPlusOptions
+    {
+        public string RDGateway;
+        public bool UseSameCredentials;
+    }
+}

--- a/QuickConnectPlugin/RdpPlusOptionsParser.cs
+++ b/QuickConnectPlugin/RdpPlusOptionsParser.cs
@@ -1,0 +1,50 @@
+﻿using System;
+
+namespace QuickConnectPlugin
+{
+    public class RdpPlusOptionsParser
+    {
+        public static bool TryParse(String str, out RdpPlusOptions options)
+        {
+            return internalParse(str, out options);
+        }
+
+        private static bool internalParse(String str, out RdpPlusOptions options)
+        {
+            options = new RdpPlusOptions();
+            if (str == null)
+            {
+                return false;
+            }
+            if (str.Trim().Length == 0)
+            {
+                return false;
+            }
+            String[] tokens = str.Split(';');
+            foreach (String token in tokens)
+            {
+                if (token.Contains(":"))
+                {
+                    String[] optionNameValue = token.Split(':');
+
+                    if (optionNameValue.Length != 2)
+                    {
+                        continue;
+                    }
+
+                    var xValue = optionNameValue[1].Trim().Trim('\"').Trim();
+                    var xKey = optionNameValue[0].Trim();
+                    if (xKey.Equals("rdgateway"))
+                    {
+                        options.RDGateway = xValue;
+                    }
+                    else if (xKey.Equals("useSameCredentials"))
+                    {
+                        options.UseSameCredentials = xValue == "yes";
+                    }
+                }
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
Add support for using Remote Desktop Gateway servers. Works using Rdp+ (See https://www.donkz.nl/)
Add settings for the gateway in same style as putty settings. ("key: value;key2: value2").

Sample:
- rdgateway: my-gateway-hostname-or-ip; useSameCredentials: yes
useSameCredentials is optional.

Specifying the path to Rdp+ should be done in the main settings form.

This PR fixes #16 
